### PR TITLE
Swagger hack

### DIFF
--- a/kie-server/kie-server-services/pom.xml
+++ b/kie-server/kie-server-services/pom.xml
@@ -35,7 +35,7 @@
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>tjws</artifactId>
-        <version>2.3.7.Final</version>
+        <version>${version.org.jboss.resteasy}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
@@ -61,6 +61,12 @@
         <groupId>com.wordnik</groupId>
         <artifactId>swagger-jaxrs_2.10</artifactId>
         <version>${version.com.wordnik.swagger}</version>
+      </dependency>
+      <!--  the scala-library version should technically be kept in sync with the version that swagger uses -->
+      <dependency>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scala-library</artifactId>
+        <version>2.10.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -191,10 +197,6 @@
     <!-- Swagger - REST documentation -->
     <dependency>
       <groupId>com.wordnik</groupId>
-      <artifactId>swagger-jersey-jaxrs_2.10</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.wordnik</groupId>
       <artifactId>swagger-annotations</artifactId>
     </dependency>
     <dependency>
@@ -206,16 +208,26 @@
       <artifactId>swagger-jaxrs_2.10</artifactId>
     </dependency>
 
+    <!-- hacking Swagger -->
+    <dependency>
+      <groupId>org.jboss.spec.javax.servlet</groupId>
+      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+    </dependency>
+    
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
     </dependency>
+    
     <!-- test dependencies -->
-    <dependency>
-      <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>tjws</artifactId>
@@ -235,7 +247,12 @@
         <directory>src/test/filtered-resources</directory>
         <filtering>true</filtering>
       </testResource>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>false</filtering>
+      </testResource>
     </testResources>
+    
     <plugins>
       <plugin>
         <!-- we need to fork always as we have mixture of both arquillian 

--- a/kie-server/kie-server-services/src/main/java/org/kie/server/services/rest/KieServerRestImpl.java
+++ b/kie-server/kie-server-services/src/main/java/org/kie/server/services/rest/KieServerRestImpl.java
@@ -1,18 +1,16 @@
 package org.kie.server.services.rest;
 
+import static org.kie.remote.common.rest.RestEasy960Util.defaultVariant;
+import static org.kie.remote.common.rest.RestEasy960Util.getVariant;
+
 import java.util.List;
 
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.Variant;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import org.kie.remote.common.rest.RestEasy960Util;
 import org.kie.server.api.commands.CommandScript;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieScannerResource;
@@ -21,10 +19,6 @@ import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.services.api.KieServer;
 import org.kie.server.services.impl.KieServerImpl;
 
-import static org.kie.remote.common.rest.RestEasy960Util.*;
-
-@Path("/server")
-@Api(value="/server",description="Kie server api for provisioning and interacting with KieContainers")
 public class KieServerRestImpl implements KieServer {
 
     private KieServerImpl server;
@@ -47,7 +41,6 @@ public class KieServerRestImpl implements KieServer {
     }
 
     @Override
-    @ApiOperation(value="Gets server info",response=Response.class)
     public Response getInfo(HttpHeaders headers) {
         return createCorrectVariant(server.getInfo(), headers);
     }
@@ -59,7 +52,6 @@ public class KieServerRestImpl implements KieServer {
     }
 
     @Override
-    @ApiOperation(value="Lists all existing KieContainers",response=Response.class)
     public Response listContainers(HttpHeaders headers) {
         return createCorrectVariant(server.listContainers(), headers);
     }

--- a/kie-server/kie-server-services/src/main/java/org/kie/server/services/rest/swagger/KieDebugJaxrsApiReader.java
+++ b/kie-server/kie-server-services/src/main/java/org/kie/server/services/rest/swagger/KieDebugJaxrsApiReader.java
@@ -1,0 +1,137 @@
+package org.kie.server.services.rest.swagger;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import scala.Option;
+import scala.Tuple3;
+import scala.collection.JavaConverters;
+import scala.collection.immutable.List;
+import scala.collection.mutable.ListBuffer;
+
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiParam;
+import com.wordnik.swagger.config.SwaggerConfig;
+import com.wordnik.swagger.jaxrs.MutableParameter;
+import com.wordnik.swagger.jaxrs.reader.BasicJaxrsReader;
+import com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader;
+import com.wordnik.swagger.model.ApiDescription;
+import com.wordnik.swagger.model.ApiListing;
+import com.wordnik.swagger.model.Operation;
+import com.wordnik.swagger.model.Parameter;
+import com.wordnik.swagger.model.ResponseMessage;
+
+/**
+ * This class can be used to replace the {@link BasicJaxrsReader} instance
+ * if for some reason we need to debug it -- or maybe hack more missing 
+ * functionality into Swagger.
+ */
+public class KieDebugJaxrsApiReader extends BasicJaxrsReader {
+
+    private Logger logger = LoggerFactory.getLogger(KieDebugJaxrsApiReader.class);
+    
+    @Override
+    public Class<?> findSubresourceType( Method method ) {
+        log();
+        return super.findSubresourceType(method);
+    }
+
+    @Override
+    public List<Field> getAllFields( Class<?> cls ) {
+        log();
+        return super.getAllFields(cls);
+    }
+
+    @Override
+    public List<Parameter> getAllParamsFromFields( Class<?> cls ) {
+        log();
+        return super.getAllParamsFromFields(cls);
+    }
+
+    @Override
+    public void parseApiParamAnnotation( MutableParameter param, ApiParam annotation ) {
+        log();
+        super.parseApiParamAnnotation(param, annotation);
+        
+    }
+
+    @Override
+    public String parseHttpMethod( Method method, ApiOperation op ) {
+        log();
+        return super.parseHttpMethod(method, op);
+    }
+
+    @Override
+    public Operation parseOperation( 
+            Method method, ApiOperation apiOperation, List<ResponseMessage> apiResponses, 
+            String isDeprecated, 
+            List<Parameter> parentParams, ListBuffer<Method> parentMethods ) {
+        log();
+        return super.parseOperation(method, apiOperation, apiResponses, isDeprecated, parentParams, parentMethods);
+    }
+
+    @Override
+    public String pathFromMethod( Method method ) {
+        log();
+        return super.pathFromMethod(method);
+    }
+
+    @Override
+    public String processDataType( Class<?> paramType, Type genericParamType ) {
+        log();
+        return super.processDataType(paramType, genericParamType);
+    }
+
+    @Override
+    public List<Parameter> processParamAnnotations( MutableParameter mutable, Annotation[] paramAnnotations ) {
+        log();
+        return super.processParamAnnotations(mutable, paramAnnotations);
+    }
+
+    @Override
+    public Option<ApiListing> read( String docRoot, Class<?> cls, SwaggerConfig config ) {
+        log();
+        Option<ApiListing> apiListOption = super.read(docRoot, cls, config);
+        if( logger.isInfoEnabled() ) { 
+            if( apiListOption.isDefined() ) { 
+                ApiListing apiList = apiListOption.get();
+                logger.info( "ApiListing: " + apiList.basePath() + "|" + apiList.apiVersion() + "|" + apiList.apis().size() );
+                for( ApiDescription apiDesc : JavaConverters.asJavaCollectionConverter(apiList.apis()).asJavaCollection() ) { 
+                    logger.info( "ApiDescription: " + apiDesc.path());
+                }
+            }
+        }
+        return apiListOption;
+    }
+
+    @Override
+    public Option<Operation> readMethod( Method method, List<Parameter> parentParams, ListBuffer<Method> parentMethods ) {
+        log();
+        return super.readMethod(method, parentParams, parentMethods);
+    }
+
+    @Override
+    public Option<ApiListing> readRecursive( 
+            String docRoot, String parentPath, 
+            Class<?> cls, SwaggerConfig config,
+            ListBuffer<Tuple3<String, String, ListBuffer<Operation>>> operations, 
+            ListBuffer<Method> parentMethods ) {
+        log();
+        return super.readRecursive(docRoot, parentPath, cls, config, operations, parentMethods);
+    }
+
+    @Override
+    public String readString( String value, String defaultValue, String ignoreValue ) {
+        log();
+        return super.readString(value, defaultValue, ignoreValue);
+    } 
+
+    private void log() { 
+        logger.info( "> " + Thread.currentThread().getStackTrace()[2].getMethodName() );
+    }
+}

--- a/kie-server/kie-server-services/src/main/java/org/kie/server/services/rest/swagger/KieReflectiveJaxrsScanner.java
+++ b/kie-server/kie-server-services/src/main/java/org/kie/server/services/rest/swagger/KieReflectiveJaxrsScanner.java
@@ -1,0 +1,95 @@
+package org.kie.server.services.rest.swagger;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.servlet.ServletConfig;
+import javax.ws.rs.core.Application;
+
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.scanners.TypeAnnotationsScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import scala.collection.JavaConverters;
+
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.config.ScannerFactory;
+import com.wordnik.swagger.jaxrs.config.JaxrsScanner;
+import com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader;
+import com.wordnik.swagger.reader.ClassReaders;
+
+public class KieReflectiveJaxrsScanner implements JaxrsScanner {
+
+    private Logger logger = LoggerFactory.getLogger(KieReflectiveJaxrsScanner.class);
+    
+    private Set<String> resourceInterfacePackages = new HashSet<String>();
+
+    public Set<String> getResourcePackages() { 
+        return resourceInterfacePackages;
+    }
+
+    /**
+     * Add package names that should be scanned for classes that have the Swagger {@link Api} annotation. 
+     * @param restApiPackage A package name
+     */
+    public void addResourcePackages(String... restApiPackage) { 
+        if( restApiPackage.length == 1 ) { 
+            this.resourceInterfacePackages.add(restApiPackage[0]);
+        } else if( restApiPackage.length > 1 ) { 
+            this.resourceInterfacePackages.addAll(Arrays.asList(restApiPackage));
+        }
+    } 
+
+    /**
+     * Configure Reflections and use the Reflections to scan for classes with the Swagger {@link Api} annotation.
+     */
+    @Override
+    public scala.collection.immutable.List<Class<?>> classesFromContext(Application app, ServletConfig sc) {
+        ConfigurationBuilder configBuilder = new ConfigurationBuilder();
+        Set<URL> pkgLocUrls = new HashSet<URL>();
+        for( String restApiPkg : resourceInterfacePackages ) { 
+            Set<URL> urls = ClasspathHelper.forPackage(restApiPkg);
+            if( urls.isEmpty() ) { 
+                logger.warn("No location found for  package '{}': this package will be skipped!", restApiPkg);
+                continue;
+            }
+            pkgLocUrls.addAll(urls);
+        }
+        configBuilder.setUrls(pkgLocUrls);
+        configBuilder.setScanners(new TypeAnnotationsScanner(), new SubTypesScanner());
+        Reflections reflections = new Reflections(configBuilder);
+       
+        Set<Class<?>> annotatedWithSwaggerApiAnno = reflections.getTypesAnnotatedWith(Api.class);
+      
+        scala.collection.immutable.List<Class<?>> resultList
+            = JavaConverters.asScalaIterableConverter(annotatedWithSwaggerApiAnno).asScala().toList();
+        
+        if( logger.isDebugEnabled() ) { 
+            logger.debug( "Swagger will provide inof on the following classes:");
+            for( Class<?> apiClass : JavaConverters.asJavaListConverter(resultList).asJava() ) { 
+                logger.debug( apiClass.getName());
+            }
+        }
+        
+        return resultList;
+    }
+
+    /**
+     * This method is never used, as far as I can tell? 
+     * It seems to be for other Swagger functionality that's not used with JAXRS/Resteasy.
+     */
+    @Override
+    public scala.collection.immutable.List<Class<?>> classes() {
+        new Throwable().printStackTrace();
+        
+        List<Class<?>> emptyClassList = Arrays.asList(new Class<?>[0]);
+        return JavaConverters.asScalaIterableConverter(emptyClassList).asScala().toList();
+    }
+}

--- a/kie-server/kie-server-services/src/main/java/org/kie/server/services/rest/swagger/KieSwaggerJaxrsConfig.java
+++ b/kie-server/kie-server-services/src/main/java/org/kie/server/services/rest/swagger/KieSwaggerJaxrsConfig.java
@@ -1,0 +1,61 @@
+package org.kie.server.services.rest.swagger;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.wordnik.swagger.config.ConfigFactory;
+import com.wordnik.swagger.config.ScannerFactory;
+import com.wordnik.swagger.jaxrs.config.WebXMLReader;
+import com.wordnik.swagger.jaxrs.reader.BasicJaxrsReader;
+import com.wordnik.swagger.reader.ClassReaders;
+
+public class KieSwaggerJaxrsConfig extends HttpServlet {
+
+    private static final Logger logger = LoggerFactory.getLogger(KieSwaggerJaxrsConfig.class);
+    
+    /** generated serial version uid */
+    private static final long serialVersionUID = 3063592528647027604L;
+
+    /**
+     * No error checking or cleaning up of the 'swagger.api.packages' property!
+     * 
+     * Please make sure that this property
+     * - does NOT end or start with a "," 
+     * - does NOT end or start with extra spaces
+     */
+    public static final String SWAGGER_API_PACKAGES_WEB_XML_PARAM = "swagger.api.packages";
+    
+    @Override
+    public void init( ServletConfig servletConfig ) throws ServletException {
+        super.init(servletConfig);
+
+        logger.debug("Initializing Swagger configuration");
+        
+        // 1. get the config values (api version, base path) we want from the web.xml
+        ConfigFactory.setConfig(new WebXMLReader(servletConfig));
+
+        // 2. force swagger to (reflectively) scan the packages we want it to
+        KieReflectiveJaxrsScanner scanner = new KieReflectiveJaxrsScanner();
+        
+        // No error checking or cleaning up of the 'swagger.api.packages' property!
+        String swaggerApiClassParam = servletConfig.getInitParameter(SWAGGER_API_PACKAGES_WEB_XML_PARAM);
+        String[] swaggerApiPkgs = swaggerApiClassParam.split(",");
+        if( logger.isDebugEnabled() ) { 
+            for( String apiPkg : swaggerApiPkgs ) { 
+                logger.debug("Classes in package '{}' will be scanned for JAX-RS and Swagger annotations.", apiPkg ); 
+            }
+        }
+        scanner.addResourcePackages(swaggerApiPkgs);
+        ScannerFactory.setScanner(scanner);
+        
+        // 3. set the API reader (part of initialization of Swagger.. )
+        // (using the BasicJaxrsReader ensures that methods that do NOT have the @ApiOperation annotation 
+        //  are also processed by Swagger)
+        ClassReaders.setReader(new BasicJaxrsReader());
+    }
+
+}

--- a/kie-server/kie-server-services/src/main/webapp/WEB-INF/web.xml
+++ b/kie-server/kie-server-services/src/main/webapp/WEB-INF/web.xml
@@ -7,6 +7,7 @@
   <listener>
     <listener-class>org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap</listener-class>
   </listener>
+  
   <servlet>
     <servlet-name>Resteasy</servlet-name>
     <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>
@@ -49,14 +50,15 @@
   <context-param>
     <param-name>resteasy.providers</param-name>
     <param-value>
+      com.wordnik.swagger.jaxrs.json.JacksonJsonProvider,
       com.wordnik.swagger.jaxrs.listing.ApiDeclarationProvider,
       com.wordnik.swagger.jaxrs.listing.ResourceListingProvider
     </param-value>
   </context-param>
 
   <servlet>
-    <servlet-name>DefaultJaxrsConfig</servlet-name>
-    <servlet-class>com.wordnik.swagger.jaxrs.config.DefaultJaxrsConfig</servlet-class>
+    <servlet-name>KieSwaggerJaxrsConfig</servlet-name>
+    <servlet-class>org.kie.server.services.rest.swagger.KieSwaggerJaxrsConfig</servlet-class>
     <init-param>
       <param-name>api.version</param-name>
       <param-value>2.0.0</param-value>
@@ -64,6 +66,10 @@
     <init-param>
       <param-name>swagger.api.basepath</param-name>
       <param-value>/services/rest</param-value>
+    </init-param>
+    <init-param>
+      <param-name>swagger.api.packages</param-name>
+      <param-value>org.kie.server.services.api</param-value>
     </init-param>
     <load-on-startup>2</load-on-startup>
   </servlet>

--- a/kie-server/kie-server-services/src/test/resources/logback-test.xml
+++ b/kie-server/kie-server-services/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <!-- %l lowers performance -->
+      <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
+      <pattern>%d [%t|%C] %-5p %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="consoleAppender" />
+  </root>
+
+</configuration>
+


### PR DESCRIPTION
It works! 

I've added/implemented a "swagger.api.packages" init parameter, that should contain a ',' (comma) separated list of packages that contain interfaces or implemenation classes whose info should be included in the Swagger API/UI. 

Once you (and/or Petr?) have verified this, we should probably move this to kie-remote-common. That way, we can configure Swagger in kie-wb to scan all of the interfaces (kie-server-services, drools-wb-rest and of course kie-remote-services). 

Re: UI work -- Have you looked at that at all? I've looked a little at it and think I know what to do, but if you have more experience with frontend stuff/javascript, it would be great if you could add that for kie-server-services (and then I can just copy it for kie-wb.. ).  
