### PR TITLE
PLANNER-505: basic integration test coverage

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/rest/RestURI.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/rest/RestURI.java
@@ -175,7 +175,7 @@ public class RestURI {
     public static final String RUN_FILTERED_QUERY_DEF_POST_URI = "{" + QUERY_NAME + "}/filtered-data";
 
     // optaplanner URI
-    public static final String SOLVER_URI = "/containers/{" + CONTAINER_ID + "}/solvers";
+    public static final String SOLVER_URI = "containers/{" + CONTAINER_ID + "}/solvers";
     public static final String SOLVER_ID_URI = "/{" + SOLVER_ID + "}";
     public static final String SOLVER_BEST_SOLUTION = "/bestsolution";
 

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/SolverServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/SolverServicesClientImpl.java
@@ -101,7 +101,7 @@ public class SolverServicesClientImpl
     }
 
     private String getURI(String containerId, String solverId) {
-        return (baseURI + RestURI.SOLVER_URI + RestURI.SOLVER_ID_URI).replace( "{"+RestURI.CONTAINER_ID+"}", containerId ).replace( "{"+RestURI.SOLVER_ID+"}", solverId );
+        return (baseURI + "/" + RestURI.SOLVER_URI + RestURI.SOLVER_ID_URI).replace( "{"+RestURI.CONTAINER_ID+"}", containerId ).replace( "{"+RestURI.SOLVER_ID+"}", solverId );
     }
 
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/resources/META-INF/cloudbalance-solver.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/resources/META-INF/cloudbalance-solver.xml
@@ -2,7 +2,7 @@
 <solver>
   <!-- Domain model configuration -->
   <solutionClass>org.kie.server.testing.CloudBalance</solutionClass>
-  <planningEntityClass>org.kie.server.testing.CloudProcess</planningEntityClass>
+  <entityClass>org.kie.server.testing.CloudProcess</entityClass>
 
   <!-- Score configuration -->
   <scoreDirectorFactory>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
@@ -21,11 +21,18 @@ import org.kie.api.KieServices;
 import org.kie.api.runtime.KieContainer;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ServiceResponse;
+import org.kie.server.api.model.ServiceResponse.ResponseType;
 import org.kie.server.api.model.instance.SolverInstance;
+import org.kie.server.api.model.instance.SolverInstance.SolverStatus;
+import org.kie.server.client.KieServicesException;
 
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class OptaplannerIntegrationTest
         extends OptaplannerKieServerBaseIntegrationTest {
@@ -64,4 +71,91 @@ public class OptaplannerIntegrationTest
         assertSuccess( solverClient.disposeSolver( CONTAINER_1_ID, SOLVER_1_ID ) );
     }
 
+    @Test
+    public void testCreateSolverFromNotExistingContainer() throws Exception {
+        SolverInstance instance = new SolverInstance();
+        instance.setSolverConfigFile( SOLVER_1_CONFIG );
+        ServiceResponse<SolverInstance> createSolverResponse = solverClient.createSolver( CONTAINER_1_ID, SOLVER_1_ID, instance );
+
+        ResponseType type = createSolverResponse.getType();
+        assertEquals("Expected FAILURE response, but got " + type + "!", ServiceResponse.ResponseType.FAILURE, type);
+        assertResultContainsString(createSolverResponse.getMsg(), "Failed to create solver. Container does not exist");
+    }
+
+    @Test
+    public void testCreateSolverWithoutSolverInstance() throws Exception {
+        ServiceResponse<SolverInstance> createSolverResponse = solverClient.createSolver(CONTAINER_1_ID, SOLVER_1_ID, null);
+
+        ResponseType type = createSolverResponse.getType();
+        assertEquals("Expected FAILURE response, but got " + type + "!", ServiceResponse.ResponseType.FAILURE, type);
+        assertResultContainsStringRegex(createSolverResponse.getMsg(), "Failed to create solver for container.*Solver configuration file is null.*");
+    }
+
+    @Test
+    public void testCreateSolverWrongSolverInstanceConfigPath() throws Exception {
+        SolverInstance instance = new SolverInstance();
+        instance.setSolverConfigFile("NonExistingPath");
+        assertSuccess( client.createContainer( CONTAINER_1_ID, new KieContainerResource( CONTAINER_1_ID, kjar1 ) ) );
+        ServiceResponse<SolverInstance> createSolverResponse = solverClient.createSolver(CONTAINER_1_ID, SOLVER_1_ID, instance);
+
+        ResponseType type = createSolverResponse.getType();
+        assertEquals("Expected FAILURE response, but got " + type + "!", ServiceResponse.ResponseType.FAILURE, type);
+        assertResultContainsStringRegex(createSolverResponse.getMsg(), ".*The solverConfigResource.*does not exist as a classpath resource in the classLoader.*");
+    }
+
+    @Test
+    public void testCreateSolverNullContainer() throws Exception {
+        ServiceResponse<SolverInstance> createSolverResponse = solverClient.createSolver(null, SOLVER_1_ID, null);
+        ResponseType type = createSolverResponse.getType();
+        assertEquals("Expected FAILURE response, but got " + type + "!", ServiceResponse.ResponseType.FAILURE, type);
+    }
+
+    @Test
+    public void testCreateDuplicitSolver() throws Exception {
+        SolverInstance instance = new SolverInstance();
+        instance.setSolverConfigFile( SOLVER_1_CONFIG );
+        assertSuccess( client.createContainer( CONTAINER_1_ID, new KieContainerResource( CONTAINER_1_ID, kjar1 ) ) );
+
+        ServiceResponse<SolverInstance> createSolverResponse = solverClient.createSolver( CONTAINER_1_ID, SOLVER_1_ID, instance );
+        assertSuccess(createSolverResponse);
+
+        createSolverResponse = solverClient.createSolver( CONTAINER_1_ID, SOLVER_1_ID, instance );
+        ResponseType type = createSolverResponse.getType();
+        assertEquals("Expected FAILURE response, but got " + type + "!", ServiceResponse.ResponseType.FAILURE, type);
+    }
+
+    @Test(expected = KieServicesException.class)
+    public void testDisposeNotExistingSolver() throws Exception {
+        solverClient.disposeSolver( CONTAINER_1_ID, SOLVER_1_ID );
+    }
+
+    @Test
+    public void testGetSolverState() throws Exception {
+        SolverInstance instance = new SolverInstance();
+        instance.setSolverConfigFile( SOLVER_1_CONFIG );
+        assertSuccess( client.createContainer( CONTAINER_1_ID, new KieContainerResource( CONTAINER_1_ID, kjar1 ) ) );
+        assertSuccess( solverClient.createSolver( CONTAINER_1_ID, SOLVER_1_ID, instance ) );
+
+        ServiceResponse<SolverInstance> solverState = solverClient.getSolverState(CONTAINER_1_ID, SOLVER_1_ID);
+        assertSuccess(solverState);
+
+        SolverInstance returnedInstance = solverState.getResult();
+        assertEquals(CONTAINER_1_ID, returnedInstance.getContainerId());
+        assertEquals(SOLVER_1_CONFIG, returnedInstance.getSolverConfigFile());
+        assertEquals(SOLVER_1_ID, returnedInstance.getSolverId());
+        assertEquals(SolverInstance.getSolverInstanceKey(CONTAINER_1_ID, SOLVER_1_ID), returnedInstance.getSolverInstanceKey());
+        assertEquals(SolverStatus.NOT_SOLVING, returnedInstance.getStatus());
+        assertNull(returnedInstance.getScore());
+    }
+
+    @Test
+    public void testGetNotExistingSolverState() throws Exception {
+        assertSuccess( client.createContainer( CONTAINER_1_ID, new KieContainerResource( CONTAINER_1_ID, kjar1 ) ) );
+
+        try {
+            solverClient.getSolverState(CONTAINER_1_ID, SOLVER_1_ID);
+        } catch (KieServicesException e) {
+            assertResultContainsStringRegex(e.getMessage(), ".*Solver.*not found in container.*");
+        }
+    }
 }


### PR DESCRIPTION
- adjusted URI to be similar as URI for other endpoints (when I tried to access endpoint in TJWS server I got 404 because path contained extra slash)
- adjusted cloudbalance-solver.xml due to parsing error

failing tests:
- testCreateSolverNullContainer - fails on NPE in URL replacing, can be avoided by using build method in RestURI?
- testDisposeNotExistingSolver - doesn't throw error or return failure if there is disposed not existing solver
- testGetSolverState - created solvers aren't stored, causing error here
- testCreateDuplicitSolver - should throw error if creating duplicit container