### PR TITLE
PLANNER-505: additional tests

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
@@ -179,6 +179,7 @@ public class JaxbMarshaller implements Marshaller {
 
                 // optaplanner
                 SolverInstance.class,
+                SolverInstanceList.class,
                 HardSoftScore.class// is this the only *Score that shall be added to jaxb???
         };
     }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/ServiceResponse.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/ServiceResponse.java
@@ -117,7 +117,8 @@ public class ServiceResponse<T> {
             @XmlElement(name = "query-definitions", type = QueryDefinitionList.class),
 
             // optaplanner entities
-            @XmlElement(name = "solver-instance", type = SolverInstance.class)//,
+            @XmlElement(name = "solver-instance", type = SolverInstance.class),
+            @XmlElement(name = "solver-instance-list", type = SolverInstanceList.class)//,
             //@XmlElement(name = "solution", type = Solution.class)
             })
     private T                            result;

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
@@ -247,7 +247,7 @@ public abstract class AbstractKieServicesClientImpl {
     @SuppressWarnings("unchecked")
     protected <T> ServiceResponse<T> makeHttpPutRequestAndCreateServiceResponse(String uri, String body, Class<T> resultType) {
         logger.debug("About to send PUT request to '{}' with payload '{}'", uri, body);
-        KieRemoteHttpRequest request = newRequest(uri).timeout( 30000 ).body(body).put();
+        KieRemoteHttpRequest request = newRequest(uri).body(body).put();
         KieRemoteHttpResponse response = request.response();
 
         if ( response.code() == Response.Status.CREATED.getStatusCode() ||

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
@@ -203,6 +203,7 @@
               <kie.server.jndi.response.queue>${kie.server.jndi.response.queue}</kie.server.jndi.response.queue>
               <org.jbpm.server.ext.disabled>${org.jbpm.server.ext.disabled}</org.jbpm.server.ext.disabled>
               <org.drools.server.ext.disabled>${org.drools.server.ext.disabled}</org.drools.server.ext.disabled>
+              <org.optaplanner.server.ext.disabled>true</org.optaplanner.server.ext.disabled>
               <kie.server.testing.kjars.build.settings.xml>${kie.server.testing.kjars.build.settings.xml}</kie.server.testing.kjars.build.settings.xml>
             </systemPropertyVariables>
           </configuration>
@@ -228,6 +229,7 @@
             <systemProperties>
               <org.jbpm.server.ext.disabled>${org.jbpm.server.ext.disabled}</org.jbpm.server.ext.disabled>
               <org.drools.server.ext.disabled>${org.drools.server.ext.disabled}</org.drools.server.ext.disabled>
+              <org.optaplanner.server.ext.disabled>true</org.optaplanner.server.ext.disabled>
               <!-- For JMS executor tests. -->
               <org.kie.executor.jms>true</org.kie.executor.jms>
             </systemProperties>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
@@ -157,6 +157,7 @@
               <org.jbpm.server.ext.disabled>true</org.jbpm.server.ext.disabled>
               <org.drools.server.ext.disabled>true</org.drools.server.ext.disabled>
               <org.jbpm.ui.server.ext.disabled>true</org.jbpm.ui.server.ext.disabled>
+              <org.optaplanner.server.ext.disabled>true</org.optaplanner.server.ext.disabled>
             </systemPropertyVariables>
           </configuration>
         </plugin>
@@ -190,6 +191,7 @@
             <systemProperties>
               <org.jbpm.server.ext.disabled>true</org.jbpm.server.ext.disabled>
               <org.drools.server.ext.disabled>true</org.drools.server.ext.disabled>
+              <org.optaplanner.server.ext.disabled>true</org.optaplanner.server.ext.disabled>
               <kie.maven.settings.custom>${project.build.testOutputDirectory}/kie-server-testing-server-custom-settings.xml</kie.maven.settings.custom>
             </systemProperties>
           </container>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
@@ -149,6 +149,7 @@
               <systemProperties>
                 <org.jbpm.server.ext.disabled>true</org.jbpm.server.ext.disabled>
                 <org.drools.server.ext.disabled>true</org.drools.server.ext.disabled>
+                <org.optaplanner.server.ext.disabled>true</org.optaplanner.server.ext.disabled>
                 <org.kie.server.location>${kie.server.base.http.url}</org.kie.server.location>
                 <org.kie.server.controller.user>yoda</org.kie.server.controller.user>
                 <org.kie.server.controller.pwd>usetheforce123@</org.kie.server.controller.pwd>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
@@ -179,6 +179,7 @@
               <org.jbpm.server.ext.disabled>true</org.jbpm.server.ext.disabled>
               <org.jbpm.ui.server.ext.disabled>true</org.jbpm.ui.server.ext.disabled>
               <org.drools.server.ext.disabled>${org.drools.server.ext.disabled}</org.drools.server.ext.disabled>
+              <org.optaplanner.server.ext.disabled>true</org.optaplanner.server.ext.disabled>
               <kie.server.testing.kjars.build.settings.xml>${kie.server.testing.kjars.build.settings.xml}</kie.server.testing.kjars.build.settings.xml>
             </systemPropertyVariables>
           </configuration>
@@ -213,6 +214,7 @@
             <systemProperties>
               <org.jbpm.server.ext.disabled>true</org.jbpm.server.ext.disabled>
               <org.drools.server.ext.disabled>${org.drools.server.ext.disabled}</org.drools.server.ext.disabled>
+              <org.optaplanner.server.ext.disabled>true</org.optaplanner.server.ext.disabled>
             </systemProperties>
           </container>
         </configuration>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
@@ -190,6 +190,7 @@
               <org.jbpm.server.ext.disabled>${org.jbpm.server.ext.disabled}</org.jbpm.server.ext.disabled>
               <org.drools.server.ext.disabled>true</org.drools.server.ext.disabled>
               <org.jbpm.ui.server.ext.disabled>true</org.jbpm.ui.server.ext.disabled>
+              <org.optaplanner.server.ext.disabled>true</org.optaplanner.server.ext.disabled>
               <kie.server.testing.kjars.build.settings.xml>${kie.server.testing.kjars.build.settings.xml}</kie.server.testing.kjars.build.settings.xml>
               <org.kie.server.persistence.ds>${org.kie.server.persistence.ds}</org.kie.server.persistence.ds>
             </systemPropertyVariables>
@@ -225,6 +226,7 @@
             <systemProperties>
               <org.jbpm.server.ext.disabled>${org.jbpm.server.ext.disabled}</org.jbpm.server.ext.disabled>
               <org.drools.server.ext.disabled>true</org.drools.server.ext.disabled>
+              <org.optaplanner.server.ext.disabled>true</org.optaplanner.server.ext.disabled>
             </systemProperties>
           </container>
         </configuration>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
@@ -189,6 +189,7 @@
               <org.jbpm.server.ext.disabled>true</org.jbpm.server.ext.disabled>
               <org.jbpm.ui.server.ext.disabled>true</org.jbpm.ui.server.ext.disabled>
               <org.drools.server.ext.disabled>${org.drools.server.ext.disabled}</org.drools.server.ext.disabled>
+              <org.optaplanner.server.ext.disabled>${org.optaplanner.server.ext.disabled}</org.optaplanner.server.ext.disabled>
               <kie.server.testing.kjars.build.settings.xml>${kie.server.testing.kjars.build.settings.xml}</kie.server.testing.kjars.build.settings.xml>
             </systemPropertyVariables>
           </configuration>
@@ -223,6 +224,7 @@
             <systemProperties>
               <org.jbpm.server.ext.disabled>true</org.jbpm.server.ext.disabled>
               <org.drools.server.ext.disabled>${org.drools.server.ext.disabled}</org.drools.server.ext.disabled>
+              <org.optaplanner.server.ext.disabled>${org.optaplanner.server.ext.disabled}</org.optaplanner.server.ext.disabled>
             </systemProperties>
           </container>
         </configuration>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kie-server-testing-client-deployment-settings.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kie-server-testing-client-deployment-settings.xml
@@ -4,4 +4,19 @@
   <!-- Using the remote repo dir here, so the kie-ci deploys the artifacts into this one, instead of the default local
        repo. FIXME this will break once the client (test class) is not on same machine as the remote repo -->
   <localRepository>${kie.server.testing.remote.repo.dir}</localRepository>
+  <profiles>
+    <profile>
+      <id>additional-maven-repos</id>
+      <repositories>
+        <repository>
+          <id>remote-testing-repo</id>
+          <url>${kie.server.testing.remote.repo.url}</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>additional-maven-repos</activeProfile>
+  </activeProfiles>
 </settings>


### PR DESCRIPTION
- small JAXB fix
- moved request timeout to OptaplannerKieServerBaseIntegrationTest
- adjusted OptaplannerKieServerExtension to not initialize if Drools extension is missing (inspired by JBPM-UI implementation)
- disabling Optaplanner extension for other test suits
- aligned deployment-settings to fix from https://github.com/droolsjbpm/droolsjbpm-integration/pull/299
- new tests:

Added checking of SolverStatus.SOLVING after solving is started, it fails most of the time as solving is asynchronous, returning SolverStatus.NOT_SOLVING.
I think that Kie server should return response of updateSolverState request after solving is started, with status SOLVING. What do you think about it?