### PR TITLE
Planner 505 some fixes

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/ServiceResponse.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/ServiceResponse.java
@@ -22,7 +22,9 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import org.drools.core.xml.jaxb.util.JaxbUnknownAdapter;
 import org.kie.server.api.model.definition.AssociatedEntitiesDefinition;
 import org.kie.server.api.model.definition.ProcessDefinition;
 import org.kie.server.api.model.definition.ProcessDefinitionList;
@@ -118,8 +120,7 @@ public class ServiceResponse<T> {
 
             // optaplanner entities
             @XmlElement(name = "solver-instance", type = SolverInstance.class),
-            @XmlElement(name = "solver-instance-list", type = SolverInstanceList.class)//,
-            //@XmlElement(name = "solution", type = Solution.class)
+            @XmlElement(name = "solver-instance-list", type = SolverInstanceList.class)
             })
     private T                            result;
 

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/SolverInstance.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/SolverInstance.java
@@ -44,6 +44,11 @@ public class SolverInstance {
     @XmlJavaTypeAdapter(JaxbUnknownAdapter.class)
     private Solution planningProblem;
 
+    @XmlElement(name = "best-solution")
+    @XStreamAlias("best-solution")
+    @XmlJavaTypeAdapter(JaxbUnknownAdapter.class)
+    private Solution bestSolution;
+
     public SolverInstance() {
     }
 
@@ -95,6 +100,14 @@ public class SolverInstance {
         this.planningProblem = planningProblem;
     }
 
+    public Solution getBestSolution() {
+        return bestSolution;
+    }
+
+    public void setBestSolution(Solution bestSolution) {
+        this.bestSolution = bestSolution;
+    }
+
     @Override
     public String toString() {
         return "SolverInstance{" +
@@ -103,7 +116,6 @@ public class SolverInstance {
                ", solverConfigFile='" + solverConfigFile + '\'' +
                ", status=" + status +
                ", score=" + score +
-               ", planningProblem=" + planningProblem +
                '}';
     }
 

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/SolverServicesClient.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/SolverServicesClient.java
@@ -28,7 +28,7 @@ public interface SolverServicesClient {
 
     ServiceResponse<SolverInstance> getSolverState( String containerId, String solverId );
 
-    ServiceResponse<Solution> getSolverBestSolution( String containerId, String solverId );
+    ServiceResponse<SolverInstance> getSolverBestSolution( String containerId, String solverId );
 
     ServiceResponse<SolverInstance> updateSolverState(String containerId, String solverId, SolverInstance instance);
 

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/helper/OptaplannerServicesClientBuilder.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/helper/OptaplannerServicesClientBuilder.java
@@ -29,7 +29,7 @@ public class OptaplannerServicesClientBuilder
 
     @Override
     public String getImplementedCapability() {
-        return "Optaplanner";
+        return "OptaPlanner";
     } // we should consolidate this into a constant in the kie-server-api jar
 
     @Override

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/SolverServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/SolverServicesClientImpl.java
@@ -83,12 +83,12 @@ public class SolverServicesClientImpl
     }
 
     @Override
-    public ServiceResponse<Solution> getSolverBestSolution(String containerId, String solverId) {
+    public ServiceResponse<SolverInstance> getSolverBestSolution(String containerId, String solverId) {
         checkMandatoryParameter( "ContainerID", containerId );
         checkMandatoryParameter( "SolverId", solverId );
         if( config.isRest() ) {
             String uri = getURI( containerId, solverId ) + RestURI.SOLVER_BEST_SOLUTION;
-            return makeHttpGetRequestAndCreateServiceResponse( uri, Solution.class );
+            return makeHttpGetRequestAndCreateServiceResponse( uri, SolverInstance.class );
         } else {
             //            CommandScript script = new CommandScript( Collections.singletonList((KieServerCommand) new CallContainerCommand(id, payload)) );
             //            return (ServiceResponse<String>) executeJmsCommand( script ).getResponses().get( 0 );

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/util/RestUtils.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/util/RestUtils.java
@@ -46,6 +46,25 @@ public class RestUtils {
         }
         return responseBuilder.build();
     }
+
+    public static Response createCorrectVariant(MarshallerHelper marshallerHelper, String containerId, Object responseObj, HttpHeaders headers, javax.ws.rs.core.Response.Status status) {
+        Response.ResponseBuilder responseBuilder = null;
+        Variant v = getVariant(headers);
+        String contentType = getContentType(headers);
+
+        String marshalledResponse;
+        if (marshallerHelper.getRegistry().getContainer(containerId) == null) {
+            marshalledResponse = marshallerHelper.marshal(contentType, responseObj);
+        } else {
+            marshalledResponse = marshallerHelper.marshal(containerId, contentType, responseObj);
+        }
+        if( status != null ) {
+            responseBuilder = Response.status(status).entity(marshalledResponse).variant(v);
+        } else {
+            responseBuilder = Response.ok(marshalledResponse, v);
+        }
+        return responseBuilder.build();
+    }
     
     public static Response createResponse(Object responseObj, Variant v, javax.ws.rs.core.Response.Status status) {
         Response.ResponseBuilder responseBuilder = null;

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-optaplanner/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-optaplanner/pom.xml
@@ -11,8 +11,8 @@
 
   <artifactId>kie-server-rest-optaplanner</artifactId>
 
-  <name>KIE :: Execution Server :: Remote :: REST :: Optaplanner</name>
-  <description>KIE Optaplanner Execution Server Extension</description>
+  <name>KIE :: Execution Server :: Remote :: REST :: OptaPlanner</name>
+  <description>KIE OptaPlanner Execution Server Extension</description>
 
   <dependencies>
     <dependency>

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-optaplanner/src/main/java/org/kie/server/remote/rest/optaplanner/SolverResource.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-optaplanner/src/main/java/org/kie/server/remote/rest/optaplanner/SolverResource.java
@@ -67,9 +67,9 @@ public class SolverResource {
         try {
             ServiceResponse<SolverInstanceList> result = solverService.getSolvers( containerId );
             if( result.getType() == ServiceResponse.ResponseType.SUCCESS ) {
-                return createCorrectVariant( result, headers, Response.Status.OK );
+                return createCorrectVariant(marshallerHelper, containerId, result, headers, Response.Status.OK );
             }
-            return createCorrectVariant( result, headers, Response.Status.NOT_FOUND );
+            return createCorrectVariant(marshallerHelper, containerId, result, headers, Response.Status.NOT_FOUND );
         }  catch (Exception e) {
             logger.error("Unexpected error retrieving solvers. Message: '{}'", e.getMessage(), e);
             return internalServerError(MessageFormat.format( Messages.UNEXPECTED_ERROR, e.getMessage()), v);
@@ -93,15 +93,15 @@ public class SolverResource {
 
             if (solverService.getKieServerRegistry().getContainer(containerId) == null) {
                 ServiceResponse<SolverInstance> response = new ServiceResponse<SolverInstance>( ServiceResponse.ResponseType.FAILURE, "Failed to create solver. Container does not exist: " + containerId );
-                return createCorrectVariant( response, headers, Response.Status.BAD_REQUEST );
+                return createCorrectVariant(response, headers, Response.Status.BAD_REQUEST );
             }
 
             SolverInstance solverInstance = marshallerHelper.unmarshal( containerId, payload, contentType, SolverInstance.class );
             ServiceResponse<SolverInstance> response = solverService.createSolver( containerId, solverId, solverInstance );
             if ( response.getType() == ServiceResponse.ResponseType.SUCCESS ) {
-                return createCorrectVariant( response, headers, Response.Status.CREATED );
+                return createCorrectVariant(marshallerHelper, containerId, response, headers, Response.Status.CREATED );
             }
-            return createCorrectVariant( response, headers, Response.Status.BAD_REQUEST );
+            return createCorrectVariant(marshallerHelper, containerId, response, headers, Response.Status.BAD_REQUEST );
         } catch ( Exception e ) {
             logger.error( "Unexpected error creating solver '{}' on container '{}': {}", solverId, containerId, e.getMessage(), e );
             return internalServerError( MessageFormat.format( Messages.UNEXPECTED_ERROR, e.getMessage() ), v );
@@ -117,9 +117,9 @@ public class SolverResource {
         try {
             ServiceResponse<SolverInstance> result = solverService.getSolverState( containerId, solverId );
             if( result.getType() == ServiceResponse.ResponseType.SUCCESS ) {
-                return createCorrectVariant( result, headers, Response.Status.OK );
+                return createCorrectVariant(marshallerHelper, containerId, result, headers, Response.Status.OK );
             }
-            return createCorrectVariant( result, headers, Response.Status.NOT_FOUND );
+            return createCorrectVariant(marshallerHelper, containerId, result, headers, Response.Status.NOT_FOUND );
         }  catch (Exception e) {
             logger.error("Unexpected error retrieving solver state {}", e.getMessage(), e);
             return internalServerError(MessageFormat.format( Messages.UNEXPECTED_ERROR, e.getMessage()), v);
@@ -133,11 +133,11 @@ public class SolverResource {
                                     @PathParam( SOLVER_ID ) String solverId ) {
         Variant v = getVariant( headers );
         try {
-            ServiceResponse<Solution> result = solverService.getBestSolution( containerId, solverId );
+            ServiceResponse<SolverInstance> result = solverService.getBestSolution( containerId, solverId );
             if( result.getType() == ServiceResponse.ResponseType.SUCCESS ) {
-                return createCorrectVariant( result, headers, Response.Status.OK );
+                return createCorrectVariant(marshallerHelper, containerId, result, headers, Response.Status.OK );
             }
-            return createCorrectVariant( result, headers, Response.Status.NOT_FOUND );
+            return createCorrectVariant(marshallerHelper, containerId, result, headers, Response.Status.NOT_FOUND );
         }  catch (Exception e) {
             logger.error("Unexpected error during processing {}", e.getMessage(), e);
             return internalServerError(MessageFormat.format( Messages.UNEXPECTED_ERROR, e.getMessage()), v);
@@ -159,9 +159,9 @@ public class SolverResource {
             SolverInstance solverInstance = marshallerHelper.unmarshal( containerId, payload, contentType, SolverInstance.class );
             ServiceResponse<SolverInstance> response = solverService.updateSolverState( containerId, solverId, solverInstance );
             if ( response.getType() == ServiceResponse.ResponseType.SUCCESS ) {
-                return createCorrectVariant( response, headers, Response.Status.OK );
+                return createCorrectVariant(marshallerHelper, containerId, response, headers, Response.Status.OK );
             }
-            return createCorrectVariant( response, headers, Response.Status.BAD_REQUEST );
+            return createCorrectVariant(marshallerHelper, containerId, response, headers, Response.Status.BAD_REQUEST );
         } catch ( Exception e ) {
             logger.error( "Unexpected error during processing {}", e.getMessage(), e );
             return internalServerError( MessageFormat.format( Messages.UNEXPECTED_ERROR, e.getMessage() ), v );
@@ -177,9 +177,9 @@ public class SolverResource {
         try {
             ServiceResponse<Void> result = solverService.disposeSolver( containerId, solverId );
             if( result.getType() == ServiceResponse.ResponseType.SUCCESS ) {
-                return createCorrectVariant( result, headers, Response.Status.OK );
+                return createCorrectVariant(marshallerHelper, containerId, result, headers, Response.Status.OK );
             }
-            return createCorrectVariant( result, headers, Response.Status.NOT_FOUND );
+            return createCorrectVariant(marshallerHelper, containerId, result, headers, Response.Status.NOT_FOUND );
         } catch (Exception e) {
             logger.error("Unexpected error disposing solver {} on container {}. Message: '{}'", solverId, containerId, e.getMessage(), e);
             return internalServerError(MessageFormat.format( Messages.UNEXPECTED_ERROR, e.getMessage()), v);

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/marshal/MarshallerHelper.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/marshal/MarshallerHelper.java
@@ -35,13 +35,19 @@ public class MarshallerHelper {
         this.registry = registry;
     }
 
+    public KieServerRegistry getRegistry() {
+        return registry;
+    }
+
     public String marshal(String containerId, String marshallingFormat, Object entity) {
         MarshallingFormat format = getFormat(marshallingFormat);
+        if (format == null) {
+            throw new IllegalArgumentException("Unknown marshalling format " + marshallingFormat);
+        }
 
         KieContainerInstance containerInstance = registry.getContainer(containerId);
-
-        if (containerInstance == null || format == null) {
-            throw new IllegalArgumentException("No container found for id " + containerId + " or unknown marshalling format " + marshallingFormat);
+        if (containerInstance == null) {
+            throw new IllegalArgumentException("No container found for id " + containerId + " .");
         }
 
         Marshaller marshaller = containerInstance.getMarshaller(format);

--- a/kie-server-parent/kie-server-services/kie-server-services-optaplanner/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-optaplanner/pom.xml
@@ -11,8 +11,8 @@
 
   <artifactId>kie-server-services-optaplanner</artifactId>
 
-  <name>KIE :: Execution Server :: Services :: Optaplanner Extension</name>
-  <description>KIE Optaplanner Execution Server Extension</description>
+  <name>KIE :: Execution Server :: Services :: OptaPlanner Extension</name>
+  <description>KIE OptaPlanner Execution Server Extension</description>
 
 
   <dependencies>

--- a/kie-server-parent/kie-server-services/kie-server-services-optaplanner/src/main/java/org/kie/server/services/optaplanner/OptaplannerKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-optaplanner/src/main/java/org/kie/server/services/optaplanner/OptaplannerKieServerExtension.java
@@ -66,11 +66,16 @@ public class OptaplannerKieServerExtension
         this.registry = registry;
         // the following threadpool will have a max thread count equal to the number of cores on the machine.
         // if new jobs are submited and all threads are busy, the reject policy will kick in.
+        int poolSize = Runtime.getRuntime().availableProcessors();
+        if (poolSize >= 4) {
+            // Leave 1 processor alone to handle REST/JMS requests and run the OS
+            poolSize--;
+        }
         this.threadPool = new ThreadPoolExecutor(2, // core size
-                                                 Runtime.getRuntime().availableProcessors(), // max size
+                poolSize, // max size
                                                  120, // idle timeout
                                                  TimeUnit.SECONDS,
-                                                 new ArrayBlockingQueue<Runnable>(Runtime.getRuntime().availableProcessors())); // queue with a size
+                                                 new ArrayBlockingQueue<Runnable>(poolSize)); // queue with a size
         this.solverServiceBase = new SolverServiceBase( registry, threadPool );
         this.services.add( solverServiceBase );
     }
@@ -89,7 +94,6 @@ public class OptaplannerKieServerExtension
     @Override
     public void disposeContainer(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters) {
         solverServiceBase.disposeSolversForContainer( id, kieContainerInstance );
-
     }
 
     @Override

--- a/kie-server-parent/kie-server-services/kie-server-services-optaplanner/src/main/java/org/kie/server/services/optaplanner/OptaplannerKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-optaplanner/src/main/java/org/kie/server/services/optaplanner/OptaplannerKieServerExtension.java
@@ -32,7 +32,7 @@ public class OptaplannerKieServerExtension
 
     private static final Logger logger = LoggerFactory.getLogger( OptaplannerKieServerExtension.class );
 
-    public static final String EXTENSION_NAME = "Optaplanner";
+    public static final String EXTENSION_NAME = "OptaPlanner";
 
     private static final Boolean droolsDisabled = Boolean.parseBoolean(System.getProperty(KieServerConstants.KIE_DROOLS_SERVER_EXT_DISABLED, "false"));
     private static final Boolean disabled = Boolean.parseBoolean( System.getProperty( KieServerConstants.KIE_OPTAPLANNER_SERVER_EXT_DISABLED, "false" ) );
@@ -114,7 +114,7 @@ public class OptaplannerKieServerExtension
 
     @Override
     public String getImplementedCapability() {
-        return "Optaplanner";
+        return "OptaPlanner";
     }
 
     @Override

--- a/kie-server-parent/kie-server-services/kie-server-services-optaplanner/src/main/java/org/kie/server/services/optaplanner/SolverServiceBase.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-optaplanner/src/main/java/org/kie/server/services/optaplanner/SolverServiceBase.java
@@ -145,22 +145,23 @@ public class SolverServiceBase {
         }
     }
 
-    public ServiceResponse<Solution> getBestSolution( String containerId, String solverId ) {
+    public ServiceResponse<SolverInstance> getBestSolution( String containerId, String solverId ) {
         try {
             SolverInstanceContext sic = solvers.get( SolverInstance.getSolverInstanceKey( containerId, solverId ) );
             if( sic != null ) {
-                Solution bestSolution = sic.getSolver().getBestSolution();
-                return new ServiceResponse<Solution>(ServiceResponse.ResponseType.SUCCESS,
+                updateSolverInstance( sic );
+                sic.getInstance().setBestSolution(sic.getSolver().getBestSolution());
+                return new ServiceResponse<SolverInstance>(ServiceResponse.ResponseType.SUCCESS,
                                                            "Best computed solution for '" + solverId + "' successfully retrieved from container '" + containerId + "'",
-                                                           bestSolution );
+                                                            sic.getInstance() );
             } else {
-                return new ServiceResponse<Solution>(ServiceResponse.ResponseType.FAILURE,
+                return new ServiceResponse<SolverInstance>(ServiceResponse.ResponseType.FAILURE,
                                                            "Solver '" + solverId + "' not found in container '" + containerId + "'",
                                                            null );
             }
         } catch (Exception e) {
             logger.error("Error retrieving solver '" + solverId + "' state from container '" + containerId + "'", e);
-            return new ServiceResponse<Solution>(ServiceResponse.ResponseType.FAILURE,
+            return new ServiceResponse<SolverInstance>(ServiceResponse.ResponseType.FAILURE,
                                                        "Error retrieving solver '" + solverId + "' state from container '" + containerId + "'" + e.getMessage(),
                                                        null );
         }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
@@ -9,7 +9,7 @@
 
   <artifactId>kie-server-integ-tests-optaplanner</artifactId>
 
-  <name>KIE :: Execution Server :: Tests :: Optaplanner Integration Tests</name>
+  <name>KIE :: Execution Server :: Tests :: OptaPlanner Integration Tests</name>
   <description>KIE Execution Server Integration Tests (REST, JMS) with configuration options to run on different containers.</description>
 
   <dependencies>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/resources/META-INF/cloudbalance-solver.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/resources/META-INF/cloudbalance-solver.xml
@@ -13,6 +13,6 @@
 
   <!-- Optimization algorithms configuration -->
   <termination>
-    <secondsSpentLimit>30</secondsSpentLimit>
+    <secondsSpentLimit>5</secondsSpentLimit>
   </termination>
 </solver>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/resources/META-INF/kmodule.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/resources/META-INF/kmodule.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<kmodule xmlns="http://jboss.org/kie/6.0.0/kmodule">
+<kmodule xmlns="http://www.drools.org/xsd/kmodule">
   <kbase name="kbase.kjar1" packages="kjar1">
     <ksession name="cloudBalancingKsession" type="stateful"/>
   </kbase>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
@@ -219,7 +219,7 @@ public class OptaplannerIntegrationTest
         assertSuccess( solverClient.disposeSolver( CONTAINER_1_ID, SOLVER_1_ID ) );
     }
 
-    @Test @Ignore("Same issue as in testTerminateEarly.")
+    @Test
     public void testExecuteRunningSolver() throws Exception {
         SolverInstance instance = new SolverInstance();
         instance.setSolverConfigFile( SOLVER_1_CONFIG );

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
@@ -244,7 +244,7 @@ public class OptaplannerIntegrationTest
         assertSuccess( solverClient.disposeSolver( CONTAINER_1_ID, SOLVER_1_ID ) );
     }
 
-    @Test @Ignore("Ignoring for now. Geoffrey will review why this is failing.")
+    @Test
     public void testGetBestSolution() throws Exception {
         SolverInstance instance = new SolverInstance();
         instance.setSolverConfigFile( SOLVER_1_CONFIG );
@@ -262,12 +262,12 @@ public class OptaplannerIntegrationTest
         Solution solution = null;
         // It can take a while for the Construction Heuristic to initialize the solution
         for (int i = 0; i < 15; i++) {
-            ServiceResponse<Solution> solutionResponse = solverClient.getSolverBestSolution(CONTAINER_1_ID, SOLVER_1_ID);
+            ServiceResponse<SolverInstance> solutionResponse = solverClient.getSolverBestSolution(CONTAINER_1_ID, SOLVER_1_ID);
             assertSuccess(solutionResponse);
-            solution = solutionResponse.getResult();
+            solution = solutionResponse.getResult().getBestSolution();
             // Only once the solution's score is null, the solution is fully uninitialized
             // TODO add "|| solution.getScore().isInitialized()" once PLANNER-405 is fixed
-            if (solution.getScore() != null) {
+            if (solution != null && solution.getScore() != null) {
                 break;
             }
             Thread.sleep(1000);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
@@ -261,7 +261,7 @@ public class OptaplannerIntegrationTest
 
         Solution solution = null;
         // It can take a while for the Construction Heuristic to initialize the solution
-        for (int i = 0; i < 30; i++) {
+        for (int i = 0; i < 15; i++) {
             ServiceResponse<Solution> solutionResponse = solverClient.getSolverBestSolution(CONTAINER_1_ID, SOLVER_1_ID);
             assertSuccess(solutionResponse);
             solution = solutionResponse.getResult();

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
@@ -209,7 +209,7 @@ public class OptaplannerIntegrationTest
 
         // solver should finish in 5 seconds, but we wait up to 15s before timing out
         for( int i = 0; i < 5 && response.getResult().getStatus() == SolverInstance.SolverStatus.SOLVING; i++ ) {
-            Thread.currentThread().sleep( 3000 );
+            Thread.sleep( 3000 );
             response = solverClient.getSolverState( CONTAINER_1_ID, SOLVER_1_ID );
             assertSuccess( response );
         }
@@ -270,7 +270,7 @@ public class OptaplannerIntegrationTest
             if (solution.getScore() != null) {
                 break;
             }
-            Thread.currentThread().sleep(1000);
+            Thread.sleep(1000);
         }
         // TODO add "|| solution.getScore().isInitialized()" once PLANNER-405 is fixed
         assertTrue(solution.getScore() != null);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
@@ -320,7 +320,7 @@ public class OptaplannerIntegrationTest
         assertResultContainsStringRegex(updateSolverState.getMsg(), "Solver.*on container.*already terminated.");
     }
 
-    @Test @Ignore("Ignoring for now. Geoffrey will review why this is failing.")
+    @Test
     public void testTerminateEarly() throws Exception {
         assertSuccess( client.createContainer( CONTAINER_1_ID, new KieContainerResource( CONTAINER_1_ID, kjar1 ) ) );
 
@@ -341,7 +341,8 @@ public class OptaplannerIntegrationTest
         instance.setStatus( SolverInstance.SolverStatus.NOT_SOLVING );
         response = solverClient.updateSolverState( CONTAINER_1_ID, SOLVER_1_ID, instance );
         assertSuccess( response );
-        assertEquals( SolverInstance.SolverStatus.TERMINATING_EARLY, response.getResult().getStatus() );
+        assertTrue(response.getResult().getStatus() == SolverInstance.SolverStatus.TERMINATING_EARLY
+                || response.getResult().getStatus() == SolverInstance.SolverStatus.NOT_SOLVING);
 
         assertSuccess( solverClient.disposeSolver( CONTAINER_1_ID, SOLVER_1_ID ) );
     }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/resources/logback-test.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/resources/logback-test.xml
@@ -4,7 +4,7 @@
     <!-- encoders are assigned the type
          ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%t] %-5p %m%n</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
Hi Edson,

I 've fixed a number of things, including the status update, but there are still a number of open issues:
- the marshalling of best solution problem
- a new unmarshalling of scores problem - https://issues.jboss.org/browse/PLANNER-535
- failing tests due to timeouts (while running in IntelliJ)
- 3 new failing tests that were false positives before. The status update fix exposes them as really failing (though timeout).
- I also see a few race conditions, that we'll need to fix in the long term. I've added TODO's for those. I want to fix these in the long term with "SolverManager" see PLANNER-338. The current reqs are just the tip of the iceberg for SolverManager (think about a solver that spawns threads themselves etc)